### PR TITLE
Add paths to Okta IWA

### DIFF
--- a/paths.dict
+++ b/paths.dict
@@ -16,8 +16,10 @@
 /ews/
 /exchange/
 /exchweb/
-/hybridconfig/
 /groupexpansion/
+/hybridconfig/
+/iwa/authenticated.aspx
+/iwa/iwa_test.aspx
 /mcx/
 /mcx/mcxservice.svc
 /meet/


### PR DESCRIPTION
These endpoints support NTLM authentication. Reference [here](https://help.okta.com/en/prod/Content/Topics/Directory/ad-iwa-test-agent.htm)
